### PR TITLE
Update azure-ai-inference from 1.0.0-beta.2 to 1.0.0-beta.3

### DIFF
--- a/langchain4j-github-models/pom.xml
+++ b/langchain4j-github-models/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -13,6 +11,15 @@
 
     <artifactId>langchain4j-github-models</artifactId>
     <name>LangChain4j :: Integration :: GitHub Models</name>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
 
     <properties>
         <netty.version>4.1.115.Final</netty.version>
@@ -28,8 +35,8 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-native-epoll</artifactId>
-                <classifier>linux-x86_64</classifier>
                 <version>${netty.version}</version>
+                <classifier>linux-x86_64</classifier>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
@@ -110,7 +117,6 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-ai-inference</artifactId>
-            <version>1.0.0-beta.2</version>
         </dependency>
 
         <dependency>
@@ -185,14 +191,5 @@
         </dependency>
 
     </dependencies>
-
-    <licenses>
-        <license>
-            <name>Apache-2.0</name>
-            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-            <comments>A business-friendly OSS license</comments>
-        </license>
-    </licenses>
 
 </project>

--- a/langchain4j-github-models/src/main/java/dev/langchain4j/model/github/InternalGitHubModelHelper.java
+++ b/langchain4j-github-models/src/main/java/dev/langchain4j/model/github/InternalGitHubModelHelper.java
@@ -181,7 +181,9 @@ class InternalGitHubModelHelper {
             return chatRequestAssistantMessage;
         } else if (message instanceof ToolExecutionResultMessage) {
             ToolExecutionResultMessage toolExecutionResultMessage = (ToolExecutionResultMessage) message;
-            return new ChatRequestToolMessage(toolExecutionResultMessage.text(), toolExecutionResultMessage.id());
+            ChatRequestToolMessage chatRequestToolMessage = new ChatRequestToolMessage(toolExecutionResultMessage.id());
+            chatRequestToolMessage.setContent(toolExecutionResultMessage.text());
+            return chatRequestToolMessage;
         } else if (message instanceof SystemMessage) {
             SystemMessage systemMessage = (SystemMessage) message;
             return new ChatRequestSystemMessage(systemMessage.text());

--- a/langchain4j-github-models/src/test/java/dev/langchain4j/model/github/GitHubModelsChatModelIT.java
+++ b/langchain4j-github-models/src/test/java/dev/langchain4j/model/github/GitHubModelsChatModelIT.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.model.github;
 
-import com.azure.ai.inference.models.ChatCompletionsResponseFormatJson;
+import com.azure.ai.inference.models.ChatCompletionsResponseFormatJsonObject;
 import com.azure.core.util.BinaryData;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -279,7 +279,7 @@ class GitHubModelsChatModelIT {
         ChatLanguageModel model = GitHubModelsChatModel.builder()
                 .gitHubToken(System.getenv("GITHUB_TOKEN"))
                 .modelName(modelName)
-                .responseFormat(new ChatCompletionsResponseFormatJson())
+                .responseFormat(new ChatCompletionsResponseFormatJsonObject())
                 .logRequestsAndResponses(true)
                 .build();
 

--- a/langchain4j-github-models/src/test/java/dev/langchain4j/model/github/GitHubModelsStreamingChatModelIT.java
+++ b/langchain4j-github-models/src/test/java/dev/langchain4j/model/github/GitHubModelsStreamingChatModelIT.java
@@ -10,7 +10,7 @@ import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.azure.ai.inference.models.ChatCompletionsResponseFormatJson;
+import com.azure.ai.inference.models.ChatCompletionsResponseFormatJsonObject;
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.AiMessage;
@@ -120,7 +120,7 @@ class GitHubModelsStreamingChatModelIT {
         StreamingChatLanguageModel model = GitHubModelsStreamingChatModel.builder()
                 .gitHubToken(System.getenv("GITHUB_TOKEN"))
                 .modelName(modelName)
-                .responseFormat(new ChatCompletionsResponseFormatJson())
+                .responseFormat(new ChatCompletionsResponseFormatJsonObject())
                 .logRequestsAndResponses(true)
                 .build();
 

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -57,6 +57,7 @@
         <!-- Dependency Versions -->
         <azure-ai-openai.version>1.0.0-beta.13</azure-ai-openai.version>
         <azure-ai-search.version>11.7.3</azure-ai-search.version>
+        <azure.ai-inference>1.0.0-beta.3</azure.ai-inference>
         <azure.storage-blob.version>12.29.0</azure.storage-blob.version>
         <azure.storage-common.version>12.28.0</azure.storage-common.version>
         <azure.identity.version>1.14.2</azure.identity.version>
@@ -108,6 +109,12 @@
                 <groupId>com.azure</groupId>
                 <artifactId>azure-search-documents</artifactId>
                 <version>${azure-ai-search.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-ai-inference</artifactId>
+                <version>${azure.ai-inference}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION

This is used in the langchain4j-github-models module.