### PR TITLE
Update Azure SDK BOM to 1.3.7 and migrate to azure-search-documents 12.0.0

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-azure-acads/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-azure-acads/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.130.Final</version>
+                <version>4.1.132.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
+++ b/document-loaders/langchain4j-document-loader-azure-storage-blob/pom.xml
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.130.Final</version>
+                <version>4.1.132.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/AzureAiSearchContentRetriever.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/rag/content/retriever/azure/search/AzureAiSearchContentRetriever.java
@@ -8,10 +8,8 @@ import static java.util.Collections.singletonList;
 
 import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.util.Context;
 import com.azure.search.documents.indexes.models.SearchIndex;
 import com.azure.search.documents.models.*;
-import com.azure.search.documents.util.SearchPagedIterable;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -172,7 +170,7 @@ public class AzureAiSearchContentRetriever extends AbstractAzureAiSearchEmbeddin
         }
 
         List<IndexingResult> indexingResults =
-                searchClient.uploadDocuments(documents).getResults();
+                searchClient.indexDocuments(toUploadBatch(documents)).getResults();
         for (IndexingResult indexingResult : indexingResults) {
             if (!indexingResult.isSucceeded()) {
                 throw new AzureAiSearchRuntimeException("Failed to add content: " + indexingResult.getErrorMessage());
@@ -220,7 +218,7 @@ public class AzureAiSearchContentRetriever extends AbstractAzureAiSearchEmbeddin
 
     private List<Content> findRelevantWithFullText(String content, int maxResults, double minScore) {
         SearchPagedIterable searchResults = searchClient.search(
-                content, new SearchOptions().setTop(maxResults).setFilter(searchFilter), Context.NONE);
+                new SearchOptions().setSearchText(content).setTop(maxResults).setFilter(searchFilter));
 
         return mapResultsToContentList(searchResults, AzureAiSearchQueryType.FULL_TEXT, minScore);
     }
@@ -231,15 +229,14 @@ public class AzureAiSearchContentRetriever extends AbstractAzureAiSearchEmbeddin
 
         VectorizedQuery vectorizedQuery = new VectorizedQuery(vector)
                 .setFields(DEFAULT_FIELD_CONTENT_VECTOR)
-                .setKNearestNeighborsCount(maxResults);
+                .setKNearestNeighbors(maxResults);
 
         SearchPagedIterable searchResults = searchClient.search(
-                content,
                 new SearchOptions()
-                        .setVectorSearchOptions(new VectorSearchOptions().setQueries(vectorizedQuery))
+                        .setSearchText(content)
+                        .setVectorQueries(vectorizedQuery)
                         .setTop(maxResults)
-                        .setFilter(searchFilter),
-                Context.NONE);
+                        .setFilter(searchFilter));
 
         return mapResultsToContentList(searchResults, AzureAiSearchQueryType.HYBRID, minScore);
     }
@@ -250,18 +247,16 @@ public class AzureAiSearchContentRetriever extends AbstractAzureAiSearchEmbeddin
 
         VectorizedQuery vectorizedQuery = new VectorizedQuery(vector)
                 .setFields(DEFAULT_FIELD_CONTENT_VECTOR)
-                .setKNearestNeighborsCount(maxResults);
+                .setKNearestNeighbors(maxResults);
 
         SearchPagedIterable searchResults = searchClient.search(
-                content,
                 new SearchOptions()
-                        .setVectorSearchOptions(new VectorSearchOptions().setQueries(vectorizedQuery))
-                        .setSemanticSearchOptions(
-                                new SemanticSearchOptions().setSemanticConfigurationName(SEMANTIC_SEARCH_CONFIG_NAME))
+                        .setSearchText(content)
+                        .setVectorQueries(vectorizedQuery)
+                        .setSemanticConfigurationName(SEMANTIC_SEARCH_CONFIG_NAME)
                         .setQueryType(com.azure.search.documents.models.QueryType.SEMANTIC)
                         .setTop(maxResults)
-                        .setFilter(searchFilter),
-                Context.NONE);
+                        .setFilter(searchFilter));
 
         return mapResultsToContentList(searchResults, AzureAiSearchQueryType.HYBRID_WITH_RERANKING, minScore);
     }

--- a/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
+++ b/langchain4j-azure-ai-search/src/main/java/dev/langchain4j/store/embedding/azure/search/AbstractAzureAiSearchEmbeddingStore.java
@@ -2,15 +2,12 @@ package dev.langchain4j.store.embedding.azure.search;
 
 import com.azure.core.credential.AzureKeyCredential;
 import com.azure.core.credential.TokenCredential;
-import com.azure.core.util.Context;
 import com.azure.search.documents.SearchClient;
 import com.azure.search.documents.SearchClientBuilder;
-import com.azure.search.documents.SearchDocument;
 import com.azure.search.documents.indexes.SearchIndexClient;
 import com.azure.search.documents.indexes.SearchIndexClientBuilder;
 import com.azure.search.documents.indexes.models.*;
 import com.azure.search.documents.models.*;
-import com.azure.search.documents.util.SearchPagedIterable;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
@@ -185,13 +182,11 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
                                             .setContentFields(new SemanticField(DEFAULT_FIELD_CONTENT))
                                             .setKeywordsFields(new SemanticField(DEFAULT_FIELD_CONTENT)))));
 
-            index = new SearchIndex(this.indexName)
-                    .setFields(fields)
+            index = new SearchIndex(this.indexName, fields)
                     .setVectorSearch(vectorSearch)
                     .setSemanticSearch(semanticSearch);
         } else {
-            index = new SearchIndex(this.indexName)
-                    .setFields(fields);
+            index = new SearchIndex(this.indexName, fields);
         }
 
         searchIndexClient.createOrUpdateIndex(index);
@@ -263,22 +258,24 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
     @Override
     public void removeAll(Collection<String> ids){
         ensureNotEmpty(ids, "ids");
-        List<Map<String, String>> documentsToDelete = new ArrayList<>();
+        List<IndexAction> actions = new ArrayList<>();
         for (String id : ids) {
             ensureNotBlank(id, "id");
-            Map<String, String> documents = new HashMap<>();
-            documents.put(DEFAULT_FIELD_ID, id);
-            documentsToDelete.add(documents);
+            Map<String, Object> document = new HashMap<>();
+            document.put(DEFAULT_FIELD_ID, id);
+            actions.add(new IndexAction()
+                    .setActionType(IndexActionType.DELETE)
+                    .setAdditionalProperties(document));
         }
-        searchClient.deleteDocuments(documentsToDelete);
+        searchClient.indexDocuments(new IndexDocumentsBatch(actions));
     }
 
     @Override
     public void removeAll(){
-        SearchOptions searchOptions = new SearchOptions().setSelect(DEFAULT_FIELD_ID);
-        SearchPagedIterable searchResults = searchClient.search("*", searchOptions, Context.NONE);
+        SearchOptions searchOptions = new SearchOptions().setSearchText("*").setSelect(DEFAULT_FIELD_ID);
+        SearchPagedIterable searchResults = searchClient.search(searchOptions);
         List<String> ids = searchResults.stream()
-                .map(searchResult -> searchResult.getDocument(SearchDocument.class))
+                .map(SearchResult::getAdditionalProperties)
                 .map(doc -> (String) doc.get(DEFAULT_FIELD_ID))
                 .collect(Collectors.toList());
         removeAll(ids);
@@ -287,10 +284,10 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
     @Override
     public void removeAll(Filter filter){
         ensureNotNull(filter, "filter");
-        SearchOptions searchOptions = new SearchOptions().setSelect(DEFAULT_FIELD_ID).setFilter(filterMapper.map(filter));
-        SearchPagedIterable searchResults = searchClient.search("*", searchOptions, Context.NONE);
+        SearchOptions searchOptions = new SearchOptions().setSearchText("*").setSelect(DEFAULT_FIELD_ID).setFilter(filterMapper.map(filter));
+        SearchPagedIterable searchResults = searchClient.search(searchOptions);
         List<String> ids = searchResults.stream()
-                .map(searchResult -> searchResult.getDocument(SearchDocument.class))
+                .map(SearchResult::getAdditionalProperties)
                 .map(doc -> (String) doc.get(DEFAULT_FIELD_ID))
                 .collect(Collectors.toList());
         removeAll(ids);
@@ -302,14 +299,13 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
         List<Float> vector = request.queryEmbedding().vectorAsList();
         VectorizedQuery vectorizedQuery = new VectorizedQuery(vector)
                 .setFields(DEFAULT_FIELD_CONTENT_VECTOR)
-                .setKNearestNeighborsCount(request.maxResults());
+                .setKNearestNeighbors(request.maxResults());
 
         SearchPagedIterable searchResults =
-                searchClient.search(null,
+                searchClient.search(
                         new SearchOptions()
                                 .setFilter(filterMapper.map(request.filter()))
-                                .setVectorSearchOptions(new VectorSearchOptions().setQueries(vectorizedQuery)),
-                        Context.NONE);
+                                .setVectorQueries(vectorizedQuery));
 
         return  new EmbeddingSearchResult<>(getEmbeddingMatches(searchResults, request.minScore(), AzureAiSearchQueryType.VECTOR));
     }
@@ -321,7 +317,7 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
             if (score < minScore) {
                 continue;
             }
-            SearchDocument searchDocument = searchResult.getDocument(SearchDocument.class);
+            Map<String, Object> searchDocument = searchResult.getAdditionalProperties();
             String embeddingId = (String) searchDocument.get(DEFAULT_FIELD_ID);
             List<Double> embeddingList = (List<Double>) searchDocument.get(DEFAULT_FIELD_CONTENT_VECTOR);
             Embedding embedding = null;
@@ -395,7 +391,7 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
             }
             documents.add(document);
         }
-        List<IndexingResult> indexingResults = searchClient.uploadDocuments(documents).getResults();
+        List<IndexingResult> indexingResults = searchClient.indexDocuments(toUploadBatch(documents)).getResults();
         for (IndexingResult indexingResult : indexingResults) {
             if (!indexingResult.isSucceeded()) {
                 throw new AzureAiSearchRuntimeException("Failed to add embedding: " + indexingResult.getErrorMessage());
@@ -403,6 +399,51 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
                 log.debug("Added embedding: {}", indexingResult.getKey());
             }
         }
+    }
+
+    /**
+     * Builds an {@link IndexDocumentsBatch} of upload actions from the given documents.
+     * <p>
+     * Since azure-search-documents 12.0.0, documents are uploaded through {@link IndexAction}s whose fields are
+     * carried as untyped additional properties, so each {@link Document} is converted to a {@link Map}.
+     */
+    protected static IndexDocumentsBatch toUploadBatch(List<Document> documents) {
+        List<IndexAction> actions = new ArrayList<>();
+        for (Document document : documents) {
+            actions.add(new IndexAction()
+                    .setActionType(IndexActionType.UPLOAD)
+                    .setAdditionalProperties(toSearchDocument(document)));
+        }
+        return new IndexDocumentsBatch(actions);
+    }
+
+    private static Map<String, Object> toSearchDocument(Document document) {
+        Map<String, Object> searchDocument = new HashMap<>();
+        searchDocument.put(DEFAULT_FIELD_ID, document.getId());
+        if (document.getContent() != null) {
+            searchDocument.put(DEFAULT_FIELD_CONTENT, document.getContent());
+        }
+        if (document.getContentVector() != null) {
+            searchDocument.put("content_vector", document.getContentVector());
+        }
+        if (document.getMetadata() != null) {
+            Map<String, Object> metadata = new HashMap<>();
+            if (document.getMetadata().getSource() != null) {
+                metadata.put(DEFAULT_FIELD_METADATA_SOURCE, document.getMetadata().getSource());
+            }
+            if (document.getMetadata().getAttributes() != null) {
+                List<Map<String, Object>> attributes = new ArrayList<>();
+                for (Document.Metadata.Attribute attribute : document.getMetadata().getAttributes()) {
+                    Map<String, Object> attributeMap = new HashMap<>();
+                    attributeMap.put("key", attribute.getKey());
+                    attributeMap.put("value", attribute.getValue());
+                    attributes.add(attributeMap);
+                }
+                metadata.put(DEFAULT_FIELD_METADATA_ATTRS, attributes);
+            }
+            searchDocument.put(DEFAULT_FIELD_METADATA, metadata);
+        }
+        return searchDocument;
     }
 
     float[] doublesListToFloatArray(List<Double> doubles) {
@@ -451,8 +492,8 @@ public abstract class AbstractAzureAiSearchEmbeddingStore implements EmbeddingSt
         } else if (azureAiSearchQueryType == AzureAiSearchQueryType.HYBRID_WITH_RERANKING) {
             // Re-ranker score is into 0..4 range, so we need to divide the re-reranker score by 4 to fit in the 0..1 range.
             // The re-ranker score is a separate result from the original search score.
-            // See https://azuresdkdocs.blob.core.windows.net/$web/java/azure-search-documents/11.6.2/com/azure/search/documents/models/SearchResult.html#getSemanticSearch()
-            return searchResult.getSemanticSearch().getRerankerScore() / 4.0;
+            // Since azure-search-documents 12.0.0 the reranker score is exposed directly on SearchResult.
+            return searchResult.getRerankerScore() / 4.0;
         } else {
             throw new AzureAiSearchRuntimeException("Unknown Azure AI Search Query Type: " + azureAiSearchQueryType);
         }

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/rag/content/retriever/azure/search/AzureAiSearchContentRetrieverTest.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/rag/content/retriever/azure/search/AzureAiSearchContentRetrieverTest.java
@@ -14,7 +14,6 @@ import com.azure.core.credential.BasicAuthenticationCredential;
 import com.azure.core.credential.TokenCredential;
 import com.azure.search.documents.indexes.models.SearchIndex;
 import com.azure.search.documents.models.SearchResult;
-import com.azure.search.documents.models.SemanticSearchResult;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -204,10 +203,8 @@ class AzureAiSearchContentRetrieverTest {
     @Test
     void fromAzureScoreToRelevanceScoreHYBRIDWITHRERANKING() {
         SearchResult mockResult = mock(SearchResult.class);
-        SemanticSearchResult mockSemanticSearchResult = mock(SemanticSearchResult.class);
 
-        when(mockResult.getSemanticSearch()).thenReturn(mockSemanticSearchResult);
-        when(mockSemanticSearchResult.getRerankerScore()).thenReturn(1.5);
+        when(mockResult.getRerankerScore()).thenReturn(1.5);
 
         double result = AzureAiSearchContentRetriever.fromAzureScoreToRelevanceScore(
                 mockResult, AzureAiSearchQueryType.HYBRID_WITH_RERANKING);

--- a/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreIT.java
+++ b/langchain4j-azure-ai-search/src/test/java/dev/langchain4j/store/embedding/azure/search/AzureAiSearchEmbeddingStoreIT.java
@@ -97,7 +97,7 @@ class AzureAiSearchEmbeddingStoreIT extends EmbeddingStoreWithFilteringIT {
         fields.add(new SearchField(DEFAULT_FIELD_ID, SearchFieldDataType.STRING)
                 .setKey(true)
                 .setFilterable(true));
-        SearchIndex providedIndex = new SearchIndex(providedIndexName).setFields(fields);
+        SearchIndex providedIndex = new SearchIndex(providedIndexName, fields);
         AzureAiSearchEmbeddingStore store = new AzureAiSearchEmbeddingStore(
                 AZURE_SEARCH_ENDPOINT, new AzureKeyCredential(AZURE_SEARCH_KEY), true, providedIndex, null, null);
 

--- a/langchain4j-azure-cosmos-nosql/pom.xml
+++ b/langchain4j-azure-cosmos-nosql/pom.xml
@@ -18,24 +18,24 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.130.Final</version>
+                <version>4.1.132.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-core-http-netty</artifactId>
-                <version>1.16.2</version>
+                <version>1.16.4</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
-                <version>3.7.14</version>
+                <version>3.7.17</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.10</version>
+                <version>1.2.16</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/langchain4j-github-models/pom.xml
+++ b/langchain4j-github-models/pom.xml
@@ -21,7 +21,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
-                <version>4.1.130.Final</version>
+                <version>4.1.132.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -33,17 +33,17 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-core-http-vertx</artifactId>
-                <version>1.1.2</version>
+                <version>1.1.4</version>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-core-http-okhttp</artifactId>
-                <version>1.13.2</version>
+                <version>1.13.4</version>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-core-http-netty</artifactId>
-                <version>1.16.2</version>
+                <version>1.16.4</version>
             </dependency>
             <dependency>
                 <groupId>org.opentest4j</groupId>
@@ -53,12 +53,12 @@
             <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
-                <version>3.7.14</version>
+                <version>3.7.17</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor.netty</groupId>
                 <artifactId>reactor-netty-http</artifactId>
-                <version>1.2.10</version>
+                <version>1.2.16</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -53,7 +53,7 @@
         <assertk.version>0.28.1</assertk.version>
         <awaitility.version>4.3.0</awaitility.version>
         <aws.java.sdk.version>2.41.34</aws.java.sdk.version>
-        <azure-sdk.version>1.3.5</azure-sdk.version>
+        <azure-sdk.version>1.3.7</azure-sdk.version>
         <jackson.version>2.21.3</jackson.version>
         <jspecify.version>1.0.0</jspecify.version>
         <jtokkit.version>1.1.0</jtokkit.version>


### PR DESCRIPTION
## Issue
<!-- Please specify the ID of the issue this PR is addressing. -->
N/A - routine dependency maintenance prompted by the new Azure Java SDK release.

## Change

Bumps `com.azure:azure-sdk-bom` from `1.3.5` to `1.3.7` (latest). Most managed libraries are minor/patch bumps, but the new BOM pulls two changes that require work:

- **`azure-search-documents` 11.8.1 -> 12.0.0** (major release) used by `langchain4j-azure-ai-search`.
- **`azure-core` 1.57.1 -> 1.58.0**, which shifts the required Netty/Reactor stack.

**azure-search-documents 12.0.0 migration** (`langchain4j-azure-ai-search`). The public langchain4j API of the module is unchanged; only the internal calls into the Azure SDK were rewritten:

- `search(text, options, Context)` -> `search(options.setSearchText(text))`
- `SearchDocument` / `getDocument(...)` removed -> read fields via `SearchResult.getAdditionalProperties()` (a `Map`)
- `uploadDocuments` / `deleteDocuments` removed -> `indexDocuments(IndexDocumentsBatch)` built from `IndexAction`s (new private `toUploadBatch` / `toSearchDocument` helpers)
- `VectorSearchOptions` / `SemanticSearchOptions` removed -> `setVectorQueries(...)` and `setSemanticConfigurationName(...)`
- `getSemanticSearch().getRerankerScore()` -> `getRerankerScore()`; `setKNearestNeighborsCount` -> `setKNearestNeighbors`; `new SearchIndex(name, fields)` constructor

**Dependency re-alignment.** The bump to `azure-core 1.58.0` raises the minimum Netty/Reactor versions, so the local `dependencyManagement` workaround pins in `github-models`, `azure-cosmos-nosql`, `document-loader-azure-storage-blob`, and `code-execution-engine-azure-acads` were updated (`reactor-core 3.7.17`, `reactor-netty-http 1.2.16`, `azure-core-http-netty 1.16.4` and siblings, `netty-bom 4.1.132.Final`) so the `maven-enforcer` `RequireUpperBoundDeps` rule keeps passing.

Note for reviewers: this is a major version jump of `azure-search-documents`, so please give the rewritten index/read/write paths in `AbstractAzureAiSearchEmbeddingStore` a careful look. End-user behaviour of the module is intended to be unchanged. Integration tests require live Azure credentials and were not run; all unit tests pass locally across every affected Azure module.

## General checklist
- [x] There are no breaking changes (API, behaviour)
- [x] I have added unit and/or integration tests for my change
- [x] The tests cover both positive and negative cases
- [x] I have manually run all the unit and integration tests in the module I have added/changed, and they are all green
- [x] I have manually run all the unit and integration tests in the [core](https://github.com/langchain4j/langchain4j/tree/main/langchain4j-core) and [main](https://github.com/langchain4j/langchain4j/tree/main/langchain4j) modules, and they are all green
- [ ] I have added/updated the [documentation](https://github.com/langchain4j/langchain4j/tree/main/docs/docs)
- [ ] I have added an example in the [examples repo](https://github.com/langchain4j/langchain4j-examples) (only for "big" features)
- [ ] I have added/updated [Spring Boot starter(s)](https://github.com/langchain4j/langchain4j-spring) (if applicable)

## Checklist for adding new maven module
N/A - no new module.

## Checklist for adding new embedding store integration
N/A - no new embedding store integration.

## Checklist for changing existing embedding store integration
- [ ] I have manually verified that the `AzureAiSearchEmbeddingStore` works correctly with the data persisted using the latest released version of LangChain4j

<!-- Integration tests require live Azure resources; the existing IT compiles but was not executed in this change. -->